### PR TITLE
return function result of hooked dispatchEvent

### DIFF
--- a/extension/src/inject.js
+++ b/extension/src/inject.js
@@ -271,7 +271,7 @@
         if (event && event.type && event.type === eventId) {
             return;
         }
-        _dispatchEvent(event);
+        return _dispatchEvent(event);
     }
 
     window.addEventListener("message", async function (x) {


### PR DESCRIPTION
returning the result of `_dispatchEvent` to callers of `document.dispatchEvent`

fixes #11 